### PR TITLE
Security Assessment: Reviewed multiple CVEs

### DIFF
--- a/vulns/CVE-2022-48935.yml
+++ b/vulns/CVE-2022-48935.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Use-after-free (UAF)
+impact: Local DoS, Potential Kernel Panic
+privileges_required: Low
+notes: This patch fixes a use-after-free issue in `nf_tables` where flowtable hooks were not unregistered before their release during net namespace exit. The race condition could lead to UAF as the hooks remained accessible after the associated resources were freed. The fix ensures proper unregistration of hooks before releasing flowtable resources, preventing crashes and maintaining stability in the Netfilter framework.
+author: Microsoft

--- a/vulns/CVE-2023-52489.yml
+++ b/vulns/CVE-2023-52489.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Null pointer dereference
+impact: Local DoS, Kernel Panic
+privileges_required: Low
+notes: This patch addresses a race condition in `mm/sparsemem` where a NULL pointer dereference could occur when accessing `memory_section->usage`. The race arises between `pfn_valid()`/`pfn_section_valid()` calls in `compact_zone` and concurrent deactivation of a memory section in another core. The fix ensures safe access to `ms->usage` by clearing `SECTION_HAS_MEM_MAP` before freeing the `usage` field and using `kfree_rcu()` for safe deallocation. This resolves kernel crashes in configurations with overlapping `ZONE_NORMAL` and `ZONE_DEVICE` PFNs.
+author: Microsoft

--- a/vulns/CVE-2023-52654.yml
+++ b/vulns/CVE-2023-52654.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: High
+notes: This change disables sending io_uring files over sockets to prevent file reference cycles, which have caused problems like races with `unix_stream_read_generic`. The change ensures robust handling of SCM_RIGHT and registered file lifecycle management.
+author: Microsoft

--- a/vulns/CVE-2023-52679.yml
+++ b/vulns/CVE-2023-52679.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Double free
+impact: Local DoS
+privileges_required: Low
+notes: This patch addresses a double free issue in `of_parse_phandle_with_args_map`, where the function assumed that the `new` pointer would be NULL on the first iteration of the inner loop. Without this guarantee, `of_node_put(new)` could attempt to free an already released reference, leading to kernel instability. The fix ensures that `new` is set to NULL after its value is assigned to `cur`. Additional unit tests are added to detect and prevent regressions.
+author: Microsoft

--- a/vulns/CVE-2024-26581.yml
+++ b/vulns/CVE-2024-26581.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: Low
+notes: This patch resolves an issue in the `nft_set_rbtree` garbage collection mechanism, where end interval elements added in the current transaction could be mistakenly collected prematurely. The fix ensures that only active elements are considered for garbage collection, preventing unintended behavior or crashes during transaction processing in Netfilter's interval-based sets.
+author: Microsoft

--- a/vulns/CVE-2024-26679.yml
+++ b/vulns/CVE-2024-26679.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: Low
+notes: This patch fixes a race condition in `inet_recv_error()` where the socket's `sk->sk_family` field could be modified concurrently without holding the socket lock. The issue occurs during the use of the `IPV6_ADDRFORM` socket option, potentially leading to inconsistent state and KCSAN warnings. The fix ensures that `sk->sk_family` is read only once, mitigating the race condition and improving reliability.
+author: Microsoft

--- a/vulns/CVE-2024-26688.yml
+++ b/vulns/CVE-2024-26688.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Null pointer dereference
+impact: Local DoS, Kernel Panic
+privileges_required: Low
+notes: This patch fixes a NULL pointer dereference in `hugetlbfs_fill_super()` when an invalid page size is passed via the `fsconfig()` syscall during hugetlbfs configuration. The issue occurs when `ctx->hstate` is set to `NULL` for an unsupported page size but later dereferenced, causing a kernel crash. The fix ensures that `ctx->hstate` is only updated if the page size is valid, preventing the dereference of a NULL pointer and maintaining system stability.
+author: Microsoft

--- a/vulns/CVE-2024-26733.yml
+++ b/vulns/CVE-2024-26733.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer overflow
+impact: Local DoS, Potential Data Corruption
+privileges_required: Low
+notes: This patch resolves a buffer overflow in `arp_req_get()` caused by an incorrect length check when copying data into `struct arpreq.arp_ha.sa_data`, which is only 14 bytes. Without this fix, packets with longer `dev->addr_len` values could overwrite adjacent fields, potentially leading to kernel instability or crashes. The fix limits the maximum length of the `memcpy()` operation to prevent out-of-bounds writes and ensures safe handling of ARP ioctl requests.
+author: Microsoft

--- a/vulns/CVE-2024-26763.yml
+++ b/vulns/CVE-2024-26763.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Data corruption
+privileges_required: Low
+notes: This patch fixes a potential data corruption issue in `dm-crypt` when using authenticated encryption. Modifications to data being encrypted could invalidate the tag, resulting in corrupted data on the device. The fix involves copying the data into a clone bio before encryption, ensuring data integrity. While this may reduce performance, it eliminates the risk of corruption during concurrent `O_DIRECT` writes.
+author: Microsoft

--- a/vulns/CVE-2024-27013.yml
+++ b/vulns/CVE-2024-27013.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: Low
+notes: This patch fixes a performance issue in the TUN driver where excessive logging of illegal packets in `tun_do_read()` could cause high CPU usage and potential soft lockups when the console is enabled. By introducing rate limiting via `net_ratelimit()`, the patch prevents excessive dumping of packet contents, ensuring system stability while handling malformed packets.
+author: Microsoft

--- a/vulns/CVE-2024-27417.yml
+++ b/vulns/CVE-2024-27417.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Resource leak
+impact: Local DoS
+privileges_required: Low
+notes: This patch fixes a potential "struct net" reference count leak in `inet6_rtm_getaddr()`. The bug occurs when a valid `IFA_TARGET_NETNSID` value is provided, but `IFA_ADDRESS` and `IFA_LOCAL` attributes are missing. This leads to an elevated reference count without proper cleanup, potentially causing resource exhaustion. The fix ensures that reference counts are correctly decremented in error paths, preventing resource leaks.
+author: Microsoft

--- a/vulns/CVE-2024-35785.yml
+++ b/vulns/CVE-2024-35785.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Invalid memory access
+impact: Local DoS, Kernel Panic
+privileges_required: Low
+notes: This patch addresses a kernel panic caused by incorrect error handling in the `optee` driver during device registration on the TEE bus. The issue stems from improper handling of errors introduced in a previous commit, leading to a level 1 translation fault and subsequent kernel crash. The fix ensures correct cleanup and handling of failure paths to prevent invalid memory accesses.
+author: Microsoft

--- a/vulns/CVE-2024-35884.yml
+++ b/vulns/CVE-2024-35884.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer mismanagement
+impact: Local DoS, Potential Data Corruption
+privileges_required: Low
+notes: This patch addresses issues in handling non-tunneled UDP GSO packets landing in a tunnel when `rx-udp-gro-forwarding` is enabled. Without proper segmentation, such packets can cause buffer mismanagement, leading to data corruption or kernel crashes. The fix ensures that GSO packets lacking `SKB_GSO_UDP_TUNNEL/_CSUM` bits and entering a tunnel are segmented to prevent misbehavior. This resolves cases like corrupted packets or crashes due to invalid offsets in `skb_fragment` or `skb_segment`.
+author: Microsoft

--- a/vulns/CVE-2024-35897.yml
+++ b/vulns/CVE-2024-35897.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: High
+notes: This patch resolves a race condition in `nf_tables` where a basechain could be deleted while leaving its hook registered in the core. This issue arises when table flag updates and basechain deletion are combined in the same operation, leading to inconsistent state. The fix ensures robust handling of such scenarios to prevent instability or crashes in the Netfilter framework.
+author: Microsoft

--- a/vulns/CVE-2024-35984.yml
+++ b/vulns/CVE-2024-35984.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Null pointer dereference
+impact: Local DoS
+privileges_required: Low
+notes: This patch fixes a NULL function pointer dereference in the `__i2c_transfer` function when the I2C designware controller operates in target-only mode. The bug was caused by the assumption that a transfer function would always be available, which is invalid for target-only configurations. This fix adds a necessary check for the function pointer to prevent kernel OOPS and crashes.
+author: Microsoft

--- a/vulns/CVE-2024-35996.yml
+++ b/vulns/CVE-2024-35996.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Configuration issue
+impact: Security hardening
+privileges_required: Low
+notes: This patch re-enables CPU mitigations by default for non-x86 architectures, addressing an oversight where generic CPU mitigations were unintentionally disabled when `SPECULATION_MITIGATIONS=n`. The change ensures consistent security settings across architectures by enabling generic mitigations while allowing x86-specific configurations. This strengthens defenses against CPU vulnerabilities, particularly on non-x86 platforms.
+author: Microsoft

--- a/vulns/CVE-2024-39276.yml
+++ b/vulns/CVE-2024-39276.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Resource leak
+impact: Local DoS
+privileges_required: Low
+notes: This patch addresses a reference count leak in the `ext4_xattr_block_cache_find()` function, which could lead to issues during `mb_cache_destroy`. The issue was triggered by failing to release a cache entry reference when `ext4_sb_bread()` returned `-ENOMEM`. This fix ensures proper cleanup of resources in the error path to prevent warnings and potential resource exhaustion.
+author: Microsoft

--- a/vulns/CVE-2024-40960.yml
+++ b/vulns/CVE-2024-40960.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Null pointer dereference
+impact: Local DoS
+privileges_required: Low
+notes: This patch fixes a potential NULL pointer dereference in `rt6_probe()` by adding a check to bail out if `__in6_dev_get()` returns NULL. The bug, reported by syzbot, could lead to a crash, resulting in a denial of service. The fix improves stability by preventing dereferencing invalid memory in IPv6 routing code.
+author: Microsoft

--- a/vulns/CVE-2024-40993.yml
+++ b/vulns/CVE-2024-40993.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: High
+notes: This patch fixes a missing check in `ip_set_dereference()` for the pernet exit phase when destroying all sets in Netfilter's ipset. The oversight could lead to incorrect usage of `rcu_dereference_protected()`, potentially causing races or unexpected behavior during cleanup. The fix ensures proper synchronization and reduces the risk of race conditions during namespace cleanup or set destruction.
+author: Microsoft

--- a/vulns/CVE-2024-41091.yml
+++ b/vulns/CVE-2024-41091.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer overflow
+impact: Local DoS, Potential Data Corruption
+privileges_required: Low
+notes: This patch addresses a missing frame length verification in the `tun_xdp_one()` path, which could lead to out-of-bound memory access or corrupted skb data. The lack of validation for short frames could cause access to invalid memory regions, potentially crashing the system or producing incorrect network traffic. The fix ensures that any frame shorter than the Ethernet header size is dropped, aligning with behavior in the `tun_get_user()` path. The issue is linked to CVE-2024-41091, highlighting its security significance.
+author: Microsoft


### PR DESCRIPTION
This commit documents the assessment of the following CVEs:

- CVE-2022-48935
- CVE-2023-52489
- CVE-2023-52654
- CVE-2023-52679
- CVE-2024-26581
- CVE-2024-26679
- CVE-2024-26688
- CVE-2024-26733
- CVE-2024-26763
- CVE-2024-27013
- CVE-2024-27417
- CVE-2024-35785
- CVE-2024-35884
- CVE-2024-35897
- CVE-2024-35984
- CVE-2024-35996
- CVE-2024-39276
- CVE-2024-40960
- CVE-2024-40993
- CVE-2024-41091

These CVEs have been thoroughly assessed and reviewed to determine their impact, exploitability, and other details. All necessary actions have been documented.