### PR TITLE
fix formatting issue due to colon in value

### DIFF
--- a/vulns/CVE-2024-42067.yml
+++ b/vulns/CVE-2024-42067.yml
@@ -3,5 +3,5 @@ memory_corruption: true
 bug_class: Integrity violation
 impact: Security hardening
 privileges_required: low
-notes: KSPP: set_memory_rox() can fail, leaving memory unprotected.
+notes: From KSPP. set_memory_rox() can fail, leaving memory unprotected.
 author: Canonical


### PR DESCRIPTION
We should be careful not to include unescaped colons (:).

Remove colon from note.