### PR TITLE
Security Assessment: Reviewed multiple CVEs

### DIFF
--- a/vulns/CVE-2023-52447.yml
+++ b/vulns/CVE-2023-52447.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Use-After-Free
+impact: Kernel Panic
+privileges_required: Low
+notes: a race condition occurs when an inner BPF map could be freed before all references to it are released.
+author: Microsoft

--- a/vulns/CVE-2023-52458.yml
+++ b/vulns/CVE-2023-52458.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Logic Error
+impact: Data Corruption
+privileges_required: Low
+notes: failing to check if partition length needs to be aligned with block size before calling add partition or resize partition.
+author: Microsoft

--- a/vulns/CVE-2023-52467.yml
+++ b/vulns/CVE-2023-52467.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Null pointer-deref
+impact: Kernel Panic
+privileges_required: Low
+notes: `kasprintf()` in `of_syscon_register()` returns a pointer to dynamically allocated memory which can be NULL.
+author: Microsoft

--- a/vulns/CVE-2023-52615.yml
+++ b/vulns/CVE-2023-52615.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Deadlock
+impact: Local DoS
+privileges_required: Low
+notes: recursive read triggers a dead-lock in the hwrng device read path.
+author: Microsoft

--- a/vulns/CVE-2023-52619.yml
+++ b/vulns/CVE-2023-52619.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: misaligned virtual addresses when the zone size is an odd number.
+author: Microsoft

--- a/vulns/CVE-2023-52620.yml
+++ b/vulns/CVE-2023-52620.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: disallow timeout for anonymous sets.
+author: Microsoft

--- a/vulns/CVE-2023-52781.yml
+++ b/vulns/CVE-2023-52781.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: 'usb_get_bos_descriptor()' encounters an iteration issue when skipping the 'USB_DT_DEVICE_CAPABILITY' descriptor type.
+author: Microsoft

--- a/vulns/CVE-2023-52828.yml
+++ b/vulns/CVE-2023-52828.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: panic seen while BPF programs with `bpf_throw` (unreliable stack unwinding).
+author: Microsoft

--- a/vulns/CVE-2023-5717.yml
+++ b/vulns/CVE-2023-5717.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer Overflow
+impact: LPE
+privileges_required: Low
+notes: write to memory locations outside of the allocated buffer while an event's sibling_list is smaller than its child's sibling_list
+author: Microsoft

--- a/vulns/CVE-2024-26640.yml
+++ b/vulns/CVE-2024-26640.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: TCP rx zerocopy intent is to map pages initially allocated from NIC drivers, not pages owned by a fs.
+author: Microsoft

--- a/vulns/CVE-2024-26643.yml
+++ b/vulns/CVE-2024-26643.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Logic Error
+impact: Data Corruption
+privileges_required: Low
+notes: rhashtable set gc runs asynchronously, a race allows it to collect elements from anonymous sets with timeouts while it is being released from the commit path.
+author: Microsoft

--- a/vulns/CVE-2024-26659.yml
+++ b/vulns/CVE-2024-26659.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Data Corruption
+privileges_required: Low
+notes: Transfer event TRB DMA ptr not part of current TD.
+author: Microsoft

--- a/vulns/CVE-2024-26671.yml
+++ b/vulns/CVE-2024-26671.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Deadlock
+impact: Hang
+privileges_required: Low
+notes: IO hang from sbitmap wakeup race in blk_mq_mark_tag_wait().
+author: Microsoft

--- a/vulns/CVE-2024-26805.yml
+++ b/vulns/CVE-2024-26805.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Info Leak
+privileges_required: Low
+notes: uninitialized memory area when copying the data.
+author: Microsoft

--- a/vulns/CVE-2024-26900.yml
+++ b/vulns/CVE-2024-26900.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Memory Leak
+impact: Local DoS
+privileges_required: Low
+notes: memory leak seen while `kobject_add()` fails, leaving `rdev->serial` unfreed.
+author: Microsoft

--- a/vulns/CVE-2024-26901.yml
+++ b/vulns/CVE-2024-26901.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: leak
+impact: infoleak
+privileges_required: Low
+notes: a kernel information leak vulnerability in do_sys_name_to_handle().
+author: Microsoft

--- a/vulns/CVE-2024-26910.yml
+++ b/vulns/CVE-2024-26910.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: High
+notes: race condition between swap/destroy and kernel side add/del/test in ipset.
+author: Microsoft

--- a/vulns/CVE-2024-26923.yml
+++ b/vulns/CVE-2024-26923.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: LPE
+privileges_required: Low
+notes: garbage collector racing against connect() in af_unix.
+author: Microsoft

--- a/vulns/CVE-2024-26935.yml
+++ b/vulns/CVE-2024-26935.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Resource leak
+impact: Memory/resource leak
+privileges_required: Low
+notes: leak of the SCSI host proc structure.
+author: Microsoft

--- a/vulns/CVE-2024-26958.yml
+++ b/vulns/CVE-2024-26958.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Use-After-Free
+impact: Local DoS
+privileges_required: Low
+notes: nfs_direct_request being completed twice in a row.
+author: Microsoft

--- a/vulns/CVE-2024-26960.yml
+++ b/vulns/CVE-2024-26960.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Use-After-Free
+impact: Local DoS
+privileges_required: Low
+notes: race condition between `free_swap_and_cache()` and `swapoff()` leading to UaF.
+author: Microsoft

--- a/vulns/CVE-2024-26988.yml
+++ b/vulns/CVE-2024-26988.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer overflow
+impact: DoS
+privileges_required: High
+notes: static command line memory overflow.
+author: Microsoft

--- a/vulns/CVE-2024-27019.yml
+++ b/vulns/CVE-2024-27019.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Local DoS
+privileges_required: Low
+notes: data-race in __nft_obj_type_get().
+author: Microsoft

--- a/vulns/CVE-2024-27020.yml
+++ b/vulns/CVE-2024-27020.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: lack of protection while iterating over nf_tables_expressions list leading to data race.
+author: Microsoft

--- a/vulns/CVE-2024-27397.yml
+++ b/vulns/CVE-2024-27397.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Data Corruption
+privileges_required: Low
+notes: element expires while control plane transaction is still unfinished.
+author: Microsoft

--- a/vulns/CVE-2024-35807.yml
+++ b/vulns/CVE-2024-35807.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Logic Error
+impact: Data Corruption
+privileges_required: High
+notes: corruption during on-line resize of a file system that is larger than 16 TiB with 4k block size.
+author: Microsoft

--- a/vulns/CVE-2024-35809.yml
+++ b/vulns/CVE-2024-35809.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: race condition between the `.runtime_idle()` and `.remove()`.
+author: Microsoft

--- a/vulns/CVE-2024-35877.yml
+++ b/vulns/CVE-2024-35877.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: incorrect handling of COW mappings in PAT, leading to WARN_ON_ONCE().
+author: Microsoft

--- a/vulns/CVE-2024-35886.yml
+++ b/vulns/CVE-2024-35886.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: kernel stack overflow seen during netlink socket destruction.
+author: Microsoft

--- a/vulns/CVE-2024-35898.yml
+++ b/vulns/CVE-2024-35898.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Data corruption
+privileges_required: Low
+notes: data-race in nf_tables_flowtables list entry.
+author: Microsoft

--- a/vulns/CVE-2024-35962.yml
+++ b/vulns/CVE-2024-35962.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Local DoS
+privileges_required: Low
+notes: user input validation failure.
+author: Microsoft

--- a/vulns/CVE-2024-36031.yml
+++ b/vulns/CVE-2024-36031.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: expiry time of a key is unconditionally overwritten during instantiation.
+author: Microsoft

--- a/vulns/CVE-2024-36883.yml
+++ b/vulns/CVE-2024-36883.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Buffer Overflow
+impact: Kernel Panic
+privileges_required: Low
+notes: a out-of-bounds memory access seen if `max_gen_ptrs` is incremented by another thred.
+author: Microsoft

--- a/vulns/CVE-2024-36959.yml
+++ b/vulns/CVE-2024-36959.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Memory Leak
+impact: DoS
+privileges_required: Low
+notes: refcount leak in pinctrl_dt_to_map().
+author: Microsoft

--- a/vulns/CVE-2024-36971.yml
+++ b/vulns/CVE-2024-36971.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: true
+bug_class: Use-After-Free
+impact: Local DoS
+privileges_required: Low
+notes: use-after-free reported when clearing `sk->dst_cache`.
+author: Microsoft

--- a/vulns/CVE-2024-38596.yml
+++ b/vulns/CVE-2024-38596.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: non-atomic reads and writes to `sk->sk_shutdown` leading to data-race.
+author: Microsoft

--- a/vulns/CVE-2024-38598.yml
+++ b/vulns/CVE-2024-38598.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: softlockup when bitmap size is less than array size.
+author: Microsoft

--- a/vulns/CVE-2024-38601.yml
+++ b/vulns/CVE-2024-38601.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: a race condition between the reader and resize operations in the ring buffer.
+author: Microsoft

--- a/vulns/CVE-2024-40945.yml
+++ b/vulns/CVE-2024-40945.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Null pointer-deref
+impact: DoS
+privileges_required: Low
+notes: `iommu_sva_bind_device()` returns an `ERR_PTR`, preventing NULL pointer deref.
+author: Microsoft

--- a/vulns/CVE-2024-41007.yml
+++ b/vulns/CVE-2024-41007.yml
@@ -1,0 +1,7 @@
+reachability: Remote
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: retransmission timers fail to respect the user-defined timeout.
+author: Microsoft

--- a/vulns/CVE-2024-42082.yml
+++ b/vulns/CVE-2024-42082.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic error
+impact: Local DoS
+privileges_required: Low
+notes: warning is triggered only when __mem_id_init_hash_table() returns an error.
+author: Microsoft

--- a/vulns/CVE-2024-42090.yml
+++ b/vulns/CVE-2024-42090.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Deadlock
+impact: DoS
+privileges_required: Low
+notes: deadlock while handling -EPROBE_DEFER In create_pinctrl().
+author: Microsoft

--- a/vulns/CVE-2024-42154.yml
+++ b/vulns/CVE-2024-42154.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Logic Error
+impact: DoS
+privileges_required: Low
+notes: no check to TCP_METRICS_ATTR_SADDR_IPV4 if it is at least 4 bytes long.
+author: Microsoft

--- a/vulns/CVE-2024-43871.yml
+++ b/vulns/CVE-2024-43871.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: false
+bug_class: Memory leak
+impact: Resource leak
+privileges_required: Low
+notes: memory leakage in devm_free_percpu() (driver API).
+author: Microsoft

--- a/vulns/CVE-2024-44968.yml
+++ b/vulns/CVE-2024-44968.yml
@@ -1,0 +1,7 @@
+reachability: Local
+memory_corruption: False
+bug_class: Logic Error
+impact: Kernel Panic
+privileges_required: Low
+notes: accessing a per-CPU pointer in preemptible context within the broadcast timer takeover logic.
+author: Microsoft


### PR DESCRIPTION
This commit documents the assessment of the following CVEs:

	CVE-2023-52447.yml
	CVE-2023-52458.yml
	CVE-2023-52467.yml
	CVE-2023-52615.yml
	CVE-2023-52619.yml
	CVE-2023-52620.yml
	CVE-2023-52781.yml
	CVE-2023-52828.yml
	CVE-2023-5717.yml
	CVE-2024-26640.yml
	CVE-2024-26643.yml
	CVE-2024-26659.yml
	CVE-2024-26671.yml
	CVE-2024-26805.yml
	CVE-2024-26900.yml
	CVE-2024-26901.yml
	CVE-2024-26910.yml
	CVE-2024-26923.yml
	CVE-2024-26935.yml
	CVE-2024-26958.yml
	CVE-2024-26960.yml
	CVE-2024-26988.yml
	CVE-2024-27019.yml
	CVE-2024-27020.yml
	CVE-2024-27397.yml
	CVE-2024-35807.yml
	CVE-2024-35809.yml
	CVE-2024-35877.yml
	CVE-2024-35886.yml
	CVE-2024-35898.yml
	CVE-2024-35962.yml
	CVE-2024-36031.yml
	CVE-2024-36883.yml
	CVE-2024-36959.yml
	CVE-2024-36971.yml
	CVE-2024-38596.yml
	CVE-2024-38598.yml
	CVE-2024-38601.yml
	CVE-2024-40945.yml
	CVE-2024-41007.yml
	CVE-2024-42082.yml
	CVE-2024-42090.yml
	CVE-2024-42154.yml
	CVE-2024-43871.yml
	CVE-2024-44968.yml