### PR TITLE
Add scripts/cve-stat.sh

### DIFF
--- a/scripts/cve-stat.sh
+++ b/scripts/cve-stat.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (c) 2025 - Allen Pais <apais@microsoft.com>
+# Copyright (c) 2025 - Matthew G. McGovern <mamcgove@microsoft.com>
+#
+#
+# cve_stat - Generate summaries of CVE data from https://github.com/cloud-lts/linux-cve-analysis
+#
+
+_filename=$(basename "$0")
+_script_dir=$(dirname "$0")
+
+# getopt arguments
+OPTIONS="i:d:h"
+LONGOPTIONS="input:,dir:,help,show-debug-stats,summary,impact,memory-corruption,author"
+
+# default directory to look for vuln yml files
+DEFAULT_YAML_DIR="$_script_dir/../vulns"
+
+# Initialize default flag values
+SHOW_DEBUG_STATS=0
+SHOW_AUTHOR_COUNTS=0
+SHOW_DEBUG_STATS=0
+SHOW_IMPACT=0
+SHOW_MEMORY_CORRUPTION_SUMMARY=0
+SHOW_SUMMARY=0
+
+# initialize associative array to track which files to scan,
+# avoids duplicate files throwing off the count when using wildcards
+# for arguments
+declare -A PROCESS_YAML_FILES
+
+# helper to get the canonical path of a file for array keys
+function canonicalize () {
+    readlink -f "$1"
+}
+
+# help message
+show_help_message() {
+    echo "Usage: $_filename [INPUT_FLAGS] [SUMMARY_FLAG]"
+    echo "Provide files with -i and/or dirs with -d arguments;"
+    echo "OR, just run without -i/-d to use default dir at $DEFAULT_YAML_DIR."
+    echo ""
+    echo "INPUT_FLAGS:"
+    echo "-i|--input <file>: path to a yaml file."
+    echo "    Note: for multiple files,"
+    echo "          use either -i <fileN> -i <fileN+1>"
+    echo "          or -i \"./path/wildcard*.yml\" (with quotes)"
+    echo "-d|--dir <path>:  path to a dir to look for yml files."
+    echo "    Note: use -d <dirN> -i <dirN+1> to add multiple files."
+    echo ""
+    echo "SUMMARY_FLAGS (provide one of the following):"
+    echo "  --summary   Show a compact summary of all information from the vuln yml files."
+    echo "  --impact    Show a summary of only the impact info."
+    echo "  --author:   Show a summary of the authors."
+    echo "  --memory-corruption:  "
+    echo "              Show a count of only the issues related to memory corruption."
+    echo "  --show-debug-stats: "
+    echo "              Show any files missing impact/author/memory_corruption info"
+}
+
+# Parse the options
+if ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTIONS --name "$0" -- "$@"); then
+    echo "$_filename: getopt could not process arguments!" 1>&2
+    exit 1
+fi
+eval set -- "$PARSED"
+while true; do
+    case "$1" in
+        -h|--help)
+            show_help_message > /dev/stderr
+            exit 0
+            ;;
+        -i|--input)
+            # Process a YAML file (can provide multiple -i N -i n+1 or quoted wildcards)
+            for file in $2; do
+                if ! [[ -f "$file" ]]; then
+                    echo "Skipping non-regular file $file..." > /dev/stderr
+                else
+                    PROCESS_YAML_FILES[$(canonicalize "$file")]=1
+                fi
+            done
+            shift 2
+            ;;
+        -d|--dir)
+            # Directory containing YAML files (update as needed)
+            if ! [[ -d "$2" ]]; then
+                echo "$2 is not a directory, skipping..." > /dev/stderr
+            else 
+                for file in "$2"/*.yml; do
+                    PROCESS_YAML_FILES[$(canonicalize "$file")]=1
+                done
+            fi
+            shift 2
+            ;;
+        --show-debug-stats)
+            SHOW_DEBUG_STATS=1
+            shift
+        ;;
+        --summary)
+            SHOW_SUMMARY=1
+            shift
+            ;;
+        --impact)
+            SHOW_IMPACT=1
+            shift
+            ;;
+        --author)
+            SHOW_AUTHOR_COUNTS=1
+            shift
+            ;;
+        --memory-corruption)
+            SHOW_MEMORY_CORRUPTION_SUMMARY=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "${#PROCESS_YAML_FILES[@]}" -eq 0 ]]; then
+    echo "No dirs/yaml files provided via -i/-d args, processing files in default dir: $DEFAULT_YAML_DIR" > /dev/stderr
+    for file in "$DEFAULT_YAML_DIR"/*.yml; do
+        if [[ -f "$file" ]]; then
+            PROCESS_YAML_FILES[$(canonicalize "$file")]=1
+        fi
+    done
+fi
+
+TOTAL_YAML_FILES_FOUND="${#PROCESS_YAML_FILES[@]}"
+
+# Initialize counters
+PROCESSED_FILES=0
+MEMORY_CORRUPTION_COUNT=0
+FOUND_MULTILINE_YAML_VALUE=0
+declare -A AUTHOR_COUNT
+declare -A IMPACT_COUNT
+
+# Initialize debug lists for files with missing info
+MISSING_AUTHOR=()
+MISSING_MEMORY_CORRUPTION_TAG=()
+MISSING_IMPACT=()
+MULTILINE_YAML_FILES=()
+
+# extract a value from a yaml file (provide key and file)
+function extract_value() {
+    local _key="$1"
+    local _file="$2"
+    # find the values, remove quotes and trim whitespace
+    {   grep -E "^$1:" "$2" \
+        | awk -F': ' '{print $2}' \
+        | tr -d '"' \
+        | sed 's/^ *//;s/ *$//' 2>/dev/null; 
+    } || {
+        return 1;
+    }
+    return 0;
+}
+
+# Process the YAML files
+for file in "${!PROCESS_YAML_FILES[@]}"; do
+    [[ -f "$file" ]] || continue  # Skip if no YAML files exist
+    ((PROCESSED_FILES+=1))
+
+    # Normalize company names (fix spacing and standardize names)
+    AUTHOR=$(
+        extract_value "author" "$file" \
+        | sed -E 's/RedHat/Red Hat/; s/Microsoft  /Microsoft/; s/Google  /Google/'\
+    ) || { MISSING_AUTHOR+=( "$file" ); }
+    
+    # Check memory corruption tag for issue
+    MEMORY_CORRUPTION=$(extract_value "memory_corruption" "$file") \
+    || { MISSING_MEMORY_CORRUPTION_TAG+=( "$file" ); }
+    
+    # Extract impact description (note: does not handle mutliple-line yml link key: | )
+    IMPACT=$(extract_value "impact" "$file") \
+    || { MISSING_IMPACT+=( "$file" ); }
+    if [[ "$IMPACT" == "|" ]] || [[ "$AUTHOR" == "|" ]] || [[ "$MEMORY_CORRUPTION" == "|" ]]; then
+        echo "Warning: multiline yaml value detected in $file" > /dev/stderr
+        ((FOUND_MULTILINE_YAML_VALUE+=1))
+        MULTILINE_YAML_FILES+=( "$file" )
+    fi
+    # Count how many issues this author has contributed to
+    [[ -n "$AUTHOR" ]] \
+    && AUTHOR_COUNT["$AUTHOR"]=$((AUTHOR_COUNT["$AUTHOR"] + 1))
+ 
+    # Count memory corruption cases
+    echo "$MEMORY_CORRUPTION" | grep -P -q "yes|true|1" \
+    && MEMORY_CORRUPTION_COUNT=$((MEMORY_CORRUPTION_COUNT + 1))
+ 
+    # Bucket the impact desciptions and count them
+    [[ -n "$IMPACT" ]] && IMPACT_COUNT["$IMPACT"]=$((IMPACT_COUNT["$IMPACT"] + 1))
+done
+
+function show_debug_summary() {
+    if ((SHOW_DEBUG_STATS)); then
+        if [[ $TOTAL_YAML_FILES_FOUND -eq 0 ]]; then
+            echo "No files were provided."
+        else
+            echo "$TOTAL_YAML_FILES_FOUND files were provided."
+        fi
+        if [[ $PROCESSED_FILES -eq 0 ]]; then
+            echo "No regular files were found to be processed."
+        else
+            echo "$PROCESSED_FILES were checked."
+        fi
+        if [[ "${#MISSING_AUTHOR[@]}" -gt 0 ]]; then
+            echo "Found ${#MISSING_AUTHOR[@]} files missing author info:"
+            for file in "${MISSING_AUTHOR[@]}"; do
+                echo "  $file"
+            done
+        fi
+        if [[ "${#MISSING_MEMORY_CORRUPTION_TAG[@]}" -gt 0 ]]; then
+            echo "Found ${#MISSING_MEMORY_CORRUPTION_TAG[@]} files missing memory corruption tag:"
+            for file in "${MISSING_MEMORY_CORRUPTION_TAG[@]}"; do
+                echo "  $file"
+            done
+        fi
+        if [[ "${#MISSING_IMPACT[@]}" -gt 0 ]]; then
+            echo "Found ${#MISSING_IMPACT[@]} files missing impact info:"
+            for file in "${MISSING_IMPACT[@]}"; do
+                echo "  $file"
+            done
+        fi
+        if ((FOUND_MULTILINE_YAML_VALUE)); then
+            echo "Found files with multiline yaml values:"
+            for file in "${MULTILINE_YAML_FILES[@]}"; do
+                echo "  $file"
+            done
+            echo "These can result in inaccurate impact, author, and memory corruption issue counts"
+        fi
+    fi
+}
+
+# Function to display summary stats
+function show_summary() {
+    echo "Total YAML files processed: $PROCESSED_FILES"
+    echo "Total memory corruption cases: $MEMORY_CORRUPTION_COUNT"
+    echo "Breakdown by author/company:"
+    for author in "${!AUTHOR_COUNT[@]}"; do
+        echo "  - $author: ${AUTHOR_COUNT[$author]}"
+    done
+    echo "Breakdown by impact:"
+    for impact in "${!IMPACT_COUNT[@]}"; do
+        echo "  - $impact: ${IMPACT_COUNT[$impact]}"
+    done
+}
+
+# Display the data based on the selected arguments
+if ((SHOW_SUMMARY)); then
+    show_summary
+elif ((SHOW_MEMORY_CORRUPTION_SUMMARY)); then
+    echo "Total memory corruption cases: $MEMORY_CORRUPTION_COUNT"
+elif ((SHOW_IMPACT)); then
+    echo "Breakdown by impact:"
+    for impact in "${!IMPACT_COUNT[@]}"; do
+        echo "  - $impact: ${IMPACT_COUNT[$impact]}"
+    done
+elif ((SHOW_AUTHOR_COUNTS)); then
+    echo "Breakdown by author/company:"
+    for author in "${!AUTHOR_COUNT[@]}"; do
+        echo "  - $author: ${AUTHOR_COUNT[$author]}"
+    done
+elif ((SHOW_DEBUG_STATS)); then
+    show_debug_summary > /dev/stderr
+else
+    show_help_message
+    exit 1
+fi


### PR DESCRIPTION
## Add a script to gather and show summaries of the CVEs in vulns/*.yml

### Features:
- Scan and display stats for authors, issue impact types, whether issues are related to memory corruption.
- Scan either by files or directories, wildcards accepted but must be quoted.
- Scan and show whether any files were skipped for missing author/impact/type information.
- Warns if a file contains multi-line yaml, this is not handled correctly yet.

#### Example output (truncated):
```
mcgov@mcgov:~/linux-cve-analysis$ scripts/cve-stat.sh  --summary 2> /dev/null
Total YAML files processed: 472
Total memory corruption cases: 154
Breakdown by author/company:
  - Yuxuan Luo <yuxuan.luo@canonical.com>: 4
  - Muhammad Falak R Wani <falakreyaz@gmail.com> (Microsoft) and Google: 1
  - Microsoft: 105
  - Red Hat, Google: 3
  - Cengiz Can <cengiz.can@canonical.com>: 1
  - Red Hat: 64
  - Muhammad Falak R Wani <falakreyaz@gmail.com> (Microsoft): 10
  - Google: 215
  - Bjoern Doebel <doebel@amazon.de>: 1
  - Canonical: 68
Breakdown by impact:
  - DoS / Info Leak: 1
  - Local DoS, Kernel Panic: 3
  - UAF: 1
  - DoS, unexpected system behavior: 1
  - Info Leak: 20
  - Hang: 1
  - Memory Leak: 1
  - fewer kernel panics: 1
  - Memory/resource leak: 1
  - KMSAN warning - could cause crash or unexpected behavior: 1
  ...
```